### PR TITLE
KP-1583 - update py3dtiles fork to the latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,22 +6,19 @@ from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 
 requirements = (
-    "numpy>=1.9.0,<1.25",
+    "numpy",
     "pyproj",
     "cython",
     "triangle",
-    "psycopg2-binary",
     "liblas",
     "laspy",
-    "numba==0.56.4",
+    "numba",
     "pyproj",
     "psutil",
     "lz4",
     "pyzmq",
     "jsonschema",
-    "pywavefront",
-    "rdp",
-    "shapely",
+    "pywavefront"
 )
 
 dev_requirements = (

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ requirements = (
     "pyproj",
     "cython",
     "triangle",
+    "psycopg2-binary",
     "liblas",
     "laspy",
     "numba",


### PR DESCRIPTION
We used forked version of this library to avoid any version conflicts. Once this PR and the one for py3ditlers are approved, I will be doing testing with 3dtools to confirm that everything is working properly before rebuilding production version of 3dtools